### PR TITLE
Refactor[reader] Changed hash_map to array_map

### DIFF
--- a/include/pch.h
+++ b/include/pch.h
@@ -19,4 +19,6 @@
 #include <filesystem>
 
 #include <limits>
+#include <cassert>
+#include <initializer_list>
 #include <iostream>

--- a/src/array_maps.cpp
+++ b/src/array_maps.cpp
@@ -1,0 +1,27 @@
+#include "pch.h"
+
+#include "enum_types.hpp"
+#include "hash_array.hpp"
+
+template <typename _ty>
+struct hash_func_objtypes
+{
+    inline constexpr _ty operator()(const char *in_str) const noexcept
+    {
+        return in_str[0] << 8 | in_str[1];
+    }
+};
+
+DECLARE_ARRAY_MAP(objtypes_array_map, 11, objtypes, std::uint16_t, hash_func_objtypes, 
+    array_map::pair{"mt",   objtypes::mtllib},
+    array_map::pair{"#\0",  objtypes::comment},
+    array_map::pair{"o\0",  objtypes::object_name},
+    array_map::pair{"v\0",  objtypes::vertex_coord},
+    array_map::pair{"vn",   objtypes::vertex_normal},
+    array_map::pair{"vt",   objtypes::vertex_texture},
+    array_map::pair{"us",   objtypes::usemtl},
+    array_map::pair{"f\0",  objtypes::face},
+    array_map::pair{"l\0",  objtypes::line},
+    array_map::pair{"s\0",  objtypes::smooth_shading},
+    array_map::pair{"\n\0", objtypes::new_line}
+)

--- a/src/array_maps.hpp
+++ b/src/array_maps.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "enum_types.hpp"
+#include "hash_array.hpp"
+
+DECLARE_GLOBAL_ARRAY_MAP(objtypes_array_map, objtypes)
+
+// namespace objtypes_array_map
+// {
+// extern const ::objtypes get(const char* str);
+// }

--- a/src/enum_types.hpp
+++ b/src/enum_types.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+enum class objtypes : unsigned int
+{
+    invalid,
+    comment,
+    mtllib,
+    object_name,
+    vertex_coord,
+    vertex_texture,
+    vertex_normal,
+    usemtl,
+    smooth_shading,
+    face,
+    line,
+    new_line
+};

--- a/src/hash_array.hpp
+++ b/src/hash_array.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <array>
+
+namespace array_map
+{
+
+template <typename _enum>
+struct pair
+{
+    std::string_view literal;
+    _enum value;
+    constexpr pair(std::string_view ll, _enum vv)
+        : literal(ll), value(vv)
+    {
+        
+    }
+};
+
+template <typename _hash_ty, template <typename> class _hash_func, typename _ty, std::size_t _size>
+constexpr std::size_t max_const_array(const std::array<_ty, _size>& arr) noexcept
+{
+    std::size_t max = 0, value = 0;
+    constexpr _hash_func<_hash_ty> hash_func;
+    for (const auto &val : arr)
+    {
+        value = static_cast<std::size_t>(hash_func(val.literal.data()));
+        if (value > max)
+        {
+            max = value;
+        }
+    }
+
+    return max + 1;
+}
+
+template <typename _hash_ty, template<typename> class _hash, typename _enum, std::size_t _arr_size>
+struct wrapper
+{
+    inline constexpr _enum operator[](const char* sv) const noexcept
+    {
+        return m_arr[m_get_key(sv)];
+    }
+
+    _hash<_hash_ty> m_get_key;
+    std::array<_enum, _arr_size> m_arr {_enum::invalid};
+};
+
+template <
+    typename                    _hash_ty,
+    template<typename> class    _hash,
+    std::size_t                 _arr_size,
+    typename                    _enum,
+    std::size_t                 _in_size,
+    template<typename> class    _pair_type
+>
+constexpr wrapper<_hash_ty, _hash, _enum, _arr_size>
+// constexpr auto
+create_thing(const std::array<_pair_type<_enum>, _in_size> &arr)
+{
+    _hash<_hash_ty> get_key;
+    
+    // constexpr std::size_t array_size = max_const_array<_hash_ty, _hash>(arr);
+
+    wrapper<_hash_ty, _hash, _enum, _arr_size> ret_wrapper {};
+    // wrapper<_hash_ty, _hash, _enum, array_size> ret_wrapper {};
+    auto &wrapper_arr = ret_wrapper.m_arr;
+
+    for (const auto &val : arr)
+    {
+        wrapper_arr[get_key(val.literal.data())] = val.value;
+    }
+
+    return ret_wrapper;
+}
+
+}
+
+
+
+/// MACRO for declaring the hash_array
+
+#define DECLARE_ARRAY_MAP(name, array_size, enum_type, hash_type, hash_class, ...) \
+static constexpr std::array<array_map::pair<enum_type>, array_size> name ## _arr { \
+    __VA_ARGS__ \
+}; \
+constexpr std::size_t name ## _size = array_map::max_const_array<hash_type, hash_class>(name ## _arr); \
+constexpr array_map::wrapper<hash_type, hash_class, enum_type, name ## _size> name = create_thing<hash_type, hash_class, name ## _size, enum_type>(name ## _arr);
+
+#define GET_GLOBAL_ARRAY_MAP(name, enum_type, hash_type, hash_class)  \
+extern constexpr std::size_t name ## _size; \
+extern constexpr array_map::wrapper<hash_type, hash_class, enum_type, name ## _size> name;
+

--- a/src/hash_array.hpp
+++ b/src/hash_array.hpp
@@ -76,18 +76,21 @@ create_thing(const std::array<_pair_type<_enum>, _in_size> &arr)
 
 }
 
-
-
 /// MACRO for declaring the hash_array
 
 #define DECLARE_ARRAY_MAP(name, array_size, enum_type, hash_type, hash_class, ...) \
-static constexpr std::array<array_map::pair<enum_type>, array_size> name ## _arr { \
+namespace name { \
+static constexpr std::array<::array_map::pair<::enum_type>, array_size> name ## _arr { \
     __VA_ARGS__ \
 }; \
-constexpr std::size_t name ## _size = array_map::max_const_array<hash_type, hash_class>(name ## _arr); \
-constexpr array_map::wrapper<hash_type, hash_class, enum_type, name ## _size> name = create_thing<hash_type, hash_class, name ## _size, enum_type>(name ## _arr);
+static constexpr std::size_t name ## _size = array_map::max_const_array<hash_type, hash_class>(name ## _arr); \
+static constexpr array_map::wrapper<hash_type, hash_class, ::enum_type, name ## _size> name = create_thing<hash_type, hash_class, name ## _size, ::enum_type>(name ## _arr); \
+const ::enum_type get(const char *str) { \
+    return name[str]; \
+} \
+}
 
-#define GET_GLOBAL_ARRAY_MAP(name, enum_type, hash_type, hash_class)  \
-extern constexpr std::size_t name ## _size; \
-extern constexpr array_map::wrapper<hash_type, hash_class, enum_type, name ## _size> name;
-
+#define DECLARE_GLOBAL_ARRAY_MAP(name, enum_type) \
+namespace name { \
+extern const ::enum_type get(const char *str); \
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 
     std::chrono::duration<float> duration = end - start;
     std::printf("%f s\n", duration.count());
-    exit(0);
+    // exit(0);
 
     mwindow.run();
     return 0;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -4,8 +4,7 @@
 #include "window.hpp"
 #include "stb_image.h"
 
-#include "enum_types.hpp"
-#include "hash_array.hpp"
+#include "array_maps.hpp"
 
 std::ofstream log_file("./logs/log.txt");
 
@@ -83,48 +82,6 @@ static std::unordered_map<std::string_view, objtypes> objtypes_map (std::begin(o
 
 #endif
 
-// static constexpr std::array<objtypes, std::numeric_limits<uint16_t>::max()> objtypes_array_map;
-
-// static constexpr std::array<objtypes, 30324> objtypes_array_map {objtypes::invalid};
-
-template <typename _ty>
-struct hash_func
-{
-    inline constexpr _ty operator()(const char *in_str) const noexcept
-    {
-        return in_str[0] << 8 | in_str[1];
-    }
-};
-
-DECLARE_ARRAY_MAP(objtypes_array_map, 11, objtypes, std::uint16_t, hash_func, 
-    array_map::pair{"mt", objtypes::mtllib},
-    array_map::pair{"#\0", objtypes::comment},
-    array_map::pair{"o\0", objtypes::object_name},
-    array_map::pair{"v\0", objtypes::vertex_coord},
-    array_map::pair{"vn", objtypes::vertex_normal},
-    array_map::pair{"vt", objtypes::vertex_texture},
-    array_map::pair{"us", objtypes::usemtl},
-    array_map::pair{"f\0", objtypes::face},
-    array_map::pair{"l\0", objtypes::line},
-    array_map::pair{"s\0", objtypes::smooth_shading},
-    array_map::pair{"\n\0", objtypes::new_line}
-)
-
-// constexpr array_map::hash_array<std::uint16_t, hash_func, 11, objtypes> objtypes_array_map(
-//     array_map::pair{"mt", objtypes::mtllib},
-//     array_map::pair{"#\0", objtypes::comment},
-//     array_map::pair{"o\0", objtypes::object_name},
-//     array_map::pair{"v\0", objtypes::vertex_coord},
-//     array_map::pair{"vn", objtypes::vertex_normal},
-//     array_map::pair{"vt", objtypes::vertex_texture},
-//     array_map::pair{"us", objtypes::usemtl},
-//     array_map::pair{"f\0", objtypes::face},
-//     array_map::pair{"l\0", objtypes::line},
-//     array_map::pair{"s\0", objtypes::smooth_shading},
-//     array_map::pair{"\n\0", objtypes::new_line}
-// );
-
-// static constexpr array_map::init::array_type_objtypes objtypes_array_map = array_map::init::init_array_map_objtypes();
 
 void strmvcnt(char *str, int str_len, int move_count)
 {
@@ -409,7 +366,7 @@ static objtypes get_type_from_buffer(std::vector<char> &buffer, std::size_t &ind
     char hash_key[2] {0};
     hash_key[0] = buffer[start];
     hash_key[1] = size == 1 ? '\0' : buffer[start + 1];
-    return { objtypes_array_map[hash_key] };
+    return { objtypes_array_map::get(hash_key) };
     return objtypes::comment;
 #endif
 }


### PR DESCRIPTION
Created a better hash map procedure, in which, now, the code is run on a array, and the hash function is a lot simpler, making it faster to execute.

In the tests made with the new code, there is observed an improvement of 0.8 s, with the current assets list.